### PR TITLE
#41 Keep slider class private

### DIFF
--- a/docs/source/apps.rst
+++ b/docs/source/apps.rst
@@ -7,8 +7,3 @@ Models
 The apps class create an app to visualise the model and its simulation.
 
 Overview:
-
-- :class:`_SliderComponent`
-
-
-.. autoclass:: _SliderComponent


### PR DESCRIPTION
Removed the _slider class from the documentation to keep it private