### PR TITLE
Github markdown support for readme

### DIFF
--- a/.github/workflows/copyright-test.yml
+++ b/.github/workflows/copyright-test.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.12
           architecture: x64
 
       - name: install seirmo

--- a/.github/workflows/coverage-test.yml
+++ b/.github/workflows/coverage-test.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.12
           architecture: x64
 
       - name: install seirmo

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.12
           architecture: x64
 
       - name: install seirmo

--- a/.github/workflows/os-tests.yml
+++ b/.github/workflows/os-tests.yml
@@ -17,10 +17,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.12
           architecture: x64

--- a/.github/workflows/os-tests.yml
+++ b/.github/workflows/os-tests.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.12
           architecture: x64
 
       - name: install seirmo

--- a/.github/workflows/style-test.yml
+++ b/.github/workflows/style-test.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.12
           architecture: x64
 
       - name: install seirmo

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: [3.8, 3.9, 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11, 3.12, 3.13]
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.10, 3.11, 3.12, 3.13]
 
     steps:
       - uses: actions/checkout@v1

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: .requirements-docs.txt
+   - method: setuptools
+     path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.9"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.requirements-docs.txt
+++ b/.requirements-docs.txt
@@ -1,0 +1,3 @@
+# Requirements for readthedocs.io
+numpy>=1.8
+sphinx>=1.5, !=1.7.3

--- a/README.md
+++ b/README.md
@@ -3,23 +3,19 @@
 [![codecov](https://codecov.io/gh/SABS-R3-Epidemiology/seirmo/branch/main/graph/badge.svg?token=D1P3CMQTDP)](https://codecov.io/gh/SABS-R3-Epidemiology/seirmo)
 [![Documentation Status](https://readthedocs.org/projects/seirmo/badge/?version=latest)](https://seirmo.readthedocs.io/en/latest/?badge=latest)
 
-
-
 ## General Information
-This program models the outbreak of an infectious disease with the SEIR model. The SEIR model is a compartmental model with four compartments: susceptible (S), exposed (but not yet infectious) (E), infectious (I), and recovered (R). Each individual is in one compartment at a time, and different rates quantify the movement of an individual from one compartment to another. 
+
+This program models the outbreak of an infectious disease with the SEIR model. The SEIR model is a compartmental model with four compartments: susceptible (S), exposed (but not yet infectious) (E), infectious (I), and recovered (R). Each individual is in one compartment at a time, and different rates quantify the movement of an individual from one compartment to another.
 
 Two submodels are defined in the program: a deterministic SEIR model and a stochastic SEIR model. Both are non-spatial and are time dependant. When the population size is small, the emergent behaviour of the two systems (deterministic and stochastic) can significantly differ. When the population size is larger, the dynamics tend to better align.
 
-
 &nbsp;
 
-
-
 ## Deterministic SEIR
+
 The deterministic model supposes that the population is large and well-mixed, and that small fluctuations in compartments do not impact the general solution. The conceptualisation of the model is illustrated below, and the parameters are described in a table below.
 
 ![SEIR model conceptualisation](./images/SEIR_model.png)
-
 
 | Parameter     | Description                                                                             | Unit |
 | ------------- | --------------------------------------------------------------------------------------- | ---- |
@@ -29,39 +25,40 @@ The deterministic model supposes that the population is large and well-mixed, an
 
 β > 0 controls the rate of tranmission, κ > 0 the rate at which exposed individuals become infectious, and γ > 0 the rate at which individuals recover. The model also requires initial conditions for each compartment: S(0), E(0), I(0), and R(0), which represent the initial number of people in each category.
 
+The deterministic model solves this set of ODEs:
 
-The deterministic model solves this set of ODEs: 
-
-<img src="https://render.githubusercontent.com/render/math?math=\frac{dS(t)}{dt} = - \beta S(t) I(t) ">
-<img src="https://render.githubusercontent.com/render/math?math=\frac{dE(t)}{dt} = \beta S(t) I(t) - \kappa E(t) ">
-<img src="https://render.githubusercontent.com/render/math?math=\frac{dI(t)}{dt} = \kappa E(t) - \gamma I(t)">
-<img src="https://render.githubusercontent.com/render/math?math=\frac{dR(t)}{dt} = \gamma I(t)">
+$$
+\frac{dS(t)}{dt} = - \beta S(t) I(t), \\\\
+\frac{dE(t)}{dt} = \beta S(t) I(t) - \kappa E(t), \\\\
+\frac{dI(t)}{dt} = \kappa E(t) - \gamma I(t), \\\\
+\frac{dR(t)}{dt} = \gamma I(t)
+$$
 
 The system of ODEs is nonlinear and must be solved by numerical integration methods. It is solved here using a forward model, using the `solve_ivp` method in the `scipy.integrate` library.
 
-
 &nbsp;
 
-
 ## Stochastic SEIR
+
 The stochastic model also supposes that the population is homogeneous, but it supposes that small fluctuations in compartments count toward the general solution. It models the population discretely and allows stochastic movements between compartments. The model can be illustrated as a set of chemical reactions:
 
 ![SEIR stochastic model reactions](./images/SEIR_stochastic_reactions.png)
 
-The model is solved using the Gillespie algorithm (see documentation here: https://en.wikipedia.org/wiki/Gillespie_algorithm). The timesteps are sampled randomly. At each timestep, only one reaction takes place, and which reaction takes place is determined randomly following their propensities. For example, for a given time t, if the reaction occuring is a susceptible individual becoming exposed, then the following changes occur in the densities:
+The model is solved using the Gillespie algorithm (see documentation [here](https://en.wikipedia.org/wiki/Gillespie_algorithm)). The timesteps are sampled randomly. At each timestep, only one reaction takes place, and which reaction takes place is determined randomly following their propensities. For example, for a given time _t_, if the reaction occuring is a susceptible individual becoming exposed, then the following changes occur in the densities:
 
-<img src="https://render.githubusercontent.com/render/math?math=S(t %2B 1)=S(t) - 1 ">
+$$
+S(t + 1)=S(t) - 1, \\\\
+E(t + 1)=E(t) + 1
+$$
 
-<img src="https://render.githubusercontent.com/render/math?math=E(t %2B 1)=E(t) %2B 1 ">
-
-where _(t+1)_ is the next timestep. 
-
+where _(t+1)_ is the next timestep.
 
 &nbsp;
 
-
 ## Installation procedure
+
 One way to install the module is to download the repositiory to your machine of choice and type the following commands in the terminal.
+
 ```bash
 git clone https://github.com/SABS-R3-Epidemiology/seirmo.git
 cd ../path/to/the/file
@@ -75,12 +72,14 @@ pip install -e .
 
 &nbsp;
 
-## Documentation 
+## Documentation
+
 Some documentation on the program's classes and methods can be found here: https://seirmo.readthedocs.io/en/latest/
 
 ### References
+
 List of ressources that can be useful for the project:
+
 * Gillespie D, 1977. Exact stochastic simulation of coupled chemical reactions (https://doi.org/10.1021/j100540a008)
 * Erban R, Chapman J and Maini P, 2007. A practical guide to stochastic simulations of reaction-diffusion processes (https://arxiv.org/abs/0704.1908)
 * Bauer F, 2008. Compartmental models in epidemiology (https://link.springer.com/chapter/10.1007/978-3-540-78911-6_2).
-

--- a/seirmo/_core.py
+++ b/seirmo/_core.py
@@ -18,7 +18,7 @@ class SEIRParameters():
 
     def configure_parameters(self, parameters: np.ndarray):
         """Set the current parameters"""
-        assert parameters.shape == (self._n_parameters,),\
+        assert parameters.shape == (self._n_parameters,), \
             f"Expected Parameter Shape {(self._n_parameters,)},\
                 but got {parameters.shape}"
         self._parameters = parameters

--- a/seirmo/_models.py
+++ b/seirmo/_models.py
@@ -257,7 +257,7 @@ class ReducedModel(ForwardModel):
             self._fixed_params_values[index] = value
 
         # If all parameters are free, set mask and values to None again
-        if np.alltrue(~self._fixed_params_mask):
+        if np.all(~self._fixed_params_mask):
             self._fixed_params_mask = None
             self._fixed_params_values = None
 

--- a/seirmo/plots/_plot_from_numpy.py
+++ b/seirmo/plots/_plot_from_numpy.py
@@ -84,8 +84,8 @@ class ConfigurablePlotter:
                             be plotted on a second x axis"""
 
         if len(data_array.shape) == 1:  # Turn any 1D input into 2D
-            if (not isinstance(times, np.ndarray) 
-                or np.sum(np.shape(times)) == 1):
+            if (not isinstance(times, np.ndarray) or
+                    np.sum(np.shape(times)) == 1):
                 # I.e. if only one np.int, or one element array
                 times = np.array(times, ndmin=2)
                 data_array = data_array[np.newaxis, :]

--- a/seirmo/plots/_plot_from_numpy.py
+++ b/seirmo/plots/_plot_from_numpy.py
@@ -25,9 +25,9 @@ class ConfigurablePlotter:
         """
         Begins creating a figure, with given number of subfigures
         Replaces init class so object can be reused"""
-        if type(subplots_rows) != int:
+        if not isinstance(subplots_rows, int):
             raise TypeError("Number of rows of subplots must be an integer")
-        if type(subplots_columns) != int:
+        if not isinstance(subplots_columns, int):
             raise TypeError("Number of columns of subplots must be an integer")
         if subplots_rows <= 0:
             raise ValueError("Number of rows of subplots must be positive")
@@ -84,7 +84,7 @@ class ConfigurablePlotter:
                             be plotted on a second x axis"""
 
         if len(data_array.shape) == 1:  # Turn any 1D input into 2D
-            if type(times) != np.ndarray or np.sum(np.shape(times)) == 1:
+            if not isinstance(times, np.ndarray) or np.sum(np.shape(times)) == 1:
                 # I.e. if only one np.int, or one element array
                 times = np.array(times, ndmin=2)
                 data_array = data_array[np.newaxis, :]
@@ -110,7 +110,7 @@ class ConfigurablePlotter:
             colours = plt.cm.viridis(np.linspace(0, 1, data_width))
         else:
             colours = matplotlib.colors.to_rgba_array(colours)
-        assert data_width == np.shape(colours)[0],\
+        assert data_width == np.shape(colours)[0], \
             'Unexpected number of colours'
 
         if isinstance(ylabels, str):

--- a/seirmo/plots/_plot_from_numpy.py
+++ b/seirmo/plots/_plot_from_numpy.py
@@ -84,7 +84,8 @@ class ConfigurablePlotter:
                             be plotted on a second x axis"""
 
         if len(data_array.shape) == 1:  # Turn any 1D input into 2D
-            if not isinstance(times, np.ndarray) or np.sum(np.shape(times)) == 1:
+            if (not isinstance(times, np.ndarray) 
+                or np.sum(np.shape(times)) == 1):
                 # I.e. if only one np.int, or one element array
                 times = np.array(times, ndmin=2)
                 data_array = data_array[np.newaxis, :]

--- a/seirmo/tests/test_plotters.py
+++ b/seirmo/tests/test_plotters.py
@@ -32,7 +32,7 @@ class TestPlotFromNumpy(unittest.TestCase):
                          'Unexpected number of subplot columns')
         self.assertEqual(figure._size, int(row_num * col_num),
                          'Unexpected number of subplots')
-        self.assertEqual(np.product(np.shape(figure._axes)),
+        self.assertEqual(np.prod(np.shape(figure._axes)),
                          int(row_num * col_num),
                          'Unexpected number of axes objects')
 


### PR DESCRIPTION
Correct broken links in public facing readme before zenodo publication, replace with github markdown
Update outdated numpy function calls in testing
Update testing version to 3.12 (note that an issue in version number parsing means I currently haven't included version 3.10 in the version matrix, as it is interpreted as 3.1)